### PR TITLE
Rollback ipython version as v8 is the latest supported by python 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ idna==3.10
 imagesize==1.4.1
 importlib_metadata==8.7.0
 ipykernel==6.29.5
-ipython==9.2.0
+ipython==8.36.0
 ipython-genutils==0.2.0
 itsdangerous==2.2.0
 jedi==0.19.2


### PR DESCRIPTION
The devcontainers uses Ubuntu 22.04 (Jammy) with the latest Python version being 3.10, while ipython 9 requires at least 3.11, and thus the postCreateCommand fails trying to install it:

```
...
ERROR: Could not find a version that satisfies the requirement ipython==9.2.0 (from versions: 0.10, 0.10.1, 0.10.2, 0.11, 0.12, 0.12.1, 0.13, 0.13.1, 0.13.2, 1.0.0, 1.1.0, 1.2.0, 1.2.1, 2.0.0, 2.1.0, 2.2.0, 2.3.0, 2.3.1, 2.4.0, 2.4.1, 3.0.0, 3.1.0, 3.2.0, 3.2.1, 3.2.2, 3.2.3, 4.0.0b1, 4.0.0, 4.0.1, 4.0.2, 4.0.3, 4.1.0rc1, 4.1.0rc2, 4.1.0, 4.1.1, 4.1.2, 4.2.0, 4.2.1, 5.0.0b1, 5.0.0b2, 5.0.0b3, 5.0.0b4, 5.0.0rc1, 5.0.0, 5.1.0, 5.2.0, 5.2.1, 5.2.2, 5.3.0, 5.4.0, 5.4.1, 5.5.0, 5.6.0, 5.7.0, 5.8.0, 5.9.0, 5.10.0, 6.0.0rc1, 6.0.0, 6.1.0, 6.2.0, 6.2.1, 6.3.0, 6.3.1, 6.4.0, 6.5.0, 7.0.0b1, 7.0.0rc1, 7.0.0, 7.0.1, 7.1.0, 7.1.1, 7.2.0, 7.3.0, 7.4.0, 7.5.0, 7.6.0, 7.6.1, 7.7.0, 7.8.0, 7.9.0, 7.10.0, 7.10.1, 7.10.2, 7.11.0, 7.11.1, 7.12.0, 7.13.0, 7.14.0, 7.15.0, 7.16.0, 7.16.1, 7.16.2, 7.16.3, 7.17.0, 7.18.0, 7.18.1, 7.19.0, 7.20.0, 7.21.0, 7.22.0, 7.23.0, 7.23.1, 7.24.0, 7.24.1, 7.25.0, 7.26.0, 7.27.0, 7.28.0, 7.29.0, 7.30.0, 7.30.1, 7.31.0, 7.31.1, 7.32.0, 7.33.0, 7.34.0, 8.0.0a1, 8.0.0b1, 8.0.0rc1, 8.0.0, 8.0.1, 8.1.0, 8.1.1, 8.2.0, 8.3.0, 8.4.0, 8.5.0, 8.6.0, 8.7.0, 8.8.0, 8.9.0, 8.10.0, 8.11.0, 8.12.0, 8.12.1, 8.12.2, 8.12.3, 8.13.0, 8.13.1, 8.13.2, 8.14.0, 8.15.0, 8.16.0, 8.16.1, 8.17.0, 8.17.1, 8.17.2, 8.18.0, 8.18.1, 8.19.0, 8.20.0, 8.21.0, 8.22.0, 8.22.1, 8.22.2, 8.23.0, 8.24.0, 8.25.0, 8.26.0, 8.27.0, 8.28.0, 8.29.0, 8.30.0, 8.31.0, 8.32.0, 8.33.0, 8.34.0, 8.35.0, 8.36.0)
ERROR: No matching distribution found for ipython==9.2.0
[105298 ms] postCreateCommand from devcontainer.json failed with exit code 1. Skipping any further user-provided commands.
```